### PR TITLE
Update icon path in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -25,12 +25,12 @@ Requirements:
   <license file="LICENSE">MIT</license>
   <url type="repository" branch="main">https://github.com/loobric/smooth-freecad</url>
   <url type="readme">https://github.com/loobric/smooth-freecad/blob/main/README.md</url>
+  <icon>freecad/Smooth/Resources/icons/Smooth.svg</icon>
   
   <content>
     <workbench>
       <classname>Smooth</classname>
       <subdirectory>freecad/Smooth</subdirectory>
-      <icon>Resources/icons/Smooth.svg</icon>
     </workbench>
   </content>
 


### PR DESCRIPTION
Update `<icon>` path in `package.xml` so it's a top-level tag as recommended by the [Addon Metadata guide on the wiki](https://wiki.freecad.org/Package_Metadata#Required_child_tags). Icons can be defined by content item but it's easier (single relative path) to specify only one for the whole package.