### PR TITLE
M2: catalog browse + create-tool-from-catalog (0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to **smooth-freecad** (the FreeCAD CAM client for Smooth) are
 recorded here. This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.0] — 2026-06-21
+
+The **M2** client: browse the server's catalog records and create tools from
+them. Tracks smooth-core 0.2.0.
+
+### Added
+- **Catalog tab** — browse `ToolCatalogRecord`s (name, manufacturer, product
+  code, geometry, provenance source); read-only, no authoring.
+- **Create tool from catalog** — makes an **unbound** server instance from the
+  catalog type and immediately materializes a local `.fctb` in the active tools
+  library, pre-filled from the catalog's nominal geometry and linked to the new
+  instance. It lands **synced** (FreeCAD's client section is written back as the
+  sync base); the instance's canonical geometry stays empty by design (the
+  nominal geometry is reachable through the catalog link). Reload the CAM tool
+  library to see the new tool in the editor.
+
+### Changed
+- **Re-vendored `loobric.py`** from smooth-core 0.2.0 (the M2 reference client):
+  `create_instance_from_catalog`, `add_to_set` / `remove_from_set`,
+  `show-tool-set`, `server_version`. Backwards-compatible — every existing call
+  site is unchanged.
+
 ## [0.2.1] — 2026-06-20
 
 ### Fixed

--- a/freecad/Smooth/SmoothDialog.py
+++ b/freecad/Smooth/SmoothDialog.py
@@ -114,8 +114,10 @@ class SmoothWindow(QtGui.QDialog):
         tools_dir = str(get_tools_dir())
         # The one CAM surface; binding lives on Machines; Audit is read-only.
         self.sync_tab = SmoothTabs.SyncTab(self, self.client, tools_dir)
+        self.catalog_tab = SmoothTabs.CatalogTab(self, self.client, tools_dir)
         self._tab_list = [
             self.sync_tab,
+            self.catalog_tab,
             SmoothTabs.MachinesTab(self, self.client),
             SmoothTabs.AuditTab(self, self.client),
         ]

--- a/freecad/Smooth/SmoothTabs.py
+++ b/freecad/Smooth/SmoothTabs.py
@@ -1024,3 +1024,125 @@ class AuditTab(_Tab):
     def selected_record(self):
         rows = self.tree.selectedItems()
         return rows[0].data(0, QtCore.Qt.UserRole) if rows else None
+
+
+# ---------------------------------------------------------------------------
+# Catalog tab (read-only browse + create-tool-from-catalog)
+# ---------------------------------------------------------------------------
+
+class CatalogTab(_Tab):
+    """Browse the catalog records (ToolCatalogRecords) and create a tool from a
+    selected one. Read-only browse: no catalog authoring/editing here. 'Create
+    tool from catalog' makes an UNBOUND server instance from the catalog type and
+    immediately materializes a local .fctb pre-filled from the catalog's nominal
+    geometry, linked to the new instance (the orchestration lives in
+    ``sync.create_tool_from_catalog``; this class only renders and fires it)."""
+
+    TITLE = "Catalog"
+    HEADERS = ["Name", "Manufacturer", "Product code", "Geometry", "Source"]
+
+    def __init__(self, window, client, tools_dir):
+        super().__init__(window, client)
+        self.tools_dir = tools_dir
+        self._records_by_id = {}
+        layout = QtGui.QVBoxLayout(self)
+        hint = QtGui.QLabel(
+            "Browse catalog records; select one and 'Create tool from catalog' to "
+            "make an unbound tool in this library, pre-filled from the catalog's "
+            "nominal geometry and linked to the new record.")
+        hint.setWordWrap(True)
+        layout.addWidget(hint)
+
+        self.tree = QtGui.QTreeWidget()
+        self.tree.setHeaderLabels(self.HEADERS)
+        self.tree.setRootIsDecorated(False)
+        self.tree.setColumnWidth(0, 220)
+        self.tree.setColumnWidth(1, 140)
+        self.tree.setColumnWidth(2, 120)
+        self.tree.setColumnWidth(3, 110)
+        self.tree.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.tree.customContextMenuRequested.connect(self._context_menu)
+        self.tree.itemSelectionChanged.connect(self._selection_changed)
+        self.tree.itemDoubleClicked.connect(lambda *a: self._create_selected())
+        layout.addWidget(self.tree)
+
+        row = QtGui.QHBoxLayout()
+        row.addStretch()
+        self.create_button = QtGui.QPushButton("Create tool from catalog")
+        self.create_button.setToolTip(
+            "Create an unbound tool from the selected catalog record and write a "
+            "local tool file pre-filled from its nominal geometry.")
+        self.create_button.clicked.connect(self._create_selected)
+        row.addWidget(self.create_button)
+        layout.addLayout(row)
+        self._selection_changed()
+
+    def _tools_dir(self):
+        return self.tools_dir
+
+    def refresh(self):
+        self.tree.clear()
+        try:
+            records = self.client.list_catalogs()
+        except SmoothError as e:
+            self.window.refresh_api_log()
+            self._notify("✗ %s" % e)
+            return
+        self.window.refresh_api_log()
+        self._records_by_id = {
+            (r.get("internal") or {}).get("id"): r for r in records}
+        rows = viewmodel.catalog_rows(records)
+        if not rows:
+            QtGui.QTreeWidgetItem(self.tree, ["(no catalog records)", "", "", "", ""])
+            self._selection_changed()
+            return
+        for r in rows:
+            item = QtGui.QTreeWidgetItem([
+                r["name"], r["manufacturer"], r["product_code"],
+                r["geometry"], r["source"]])
+            item.setData(0, QtCore.Qt.UserRole, r["id"])
+            self.tree.addTopLevelItem(item)
+        self._selection_changed()
+
+    def selected_record(self):
+        rows = self.tree.selectedItems()
+        if not rows:
+            return None
+        rid = rows[0].data(0, QtCore.Qt.UserRole)
+        return self._records_by_id.get(rid) if rid else None
+
+    def _selection_changed(self):
+        self.create_button.setEnabled(self.selected_record() is not None)
+
+    def _context_menu(self, point):
+        at = self.tree.itemAt(point)
+        if at is not None:
+            self.tree.setCurrentItem(at)
+        if self.selected_record() is None:
+            return
+        menu = QtGui.QMenu(self)
+        inspect = menu.addAction("Inspect record (JSON)…")
+        create = menu.addAction("Create tool from catalog")
+        chosen = menu.exec_(self.tree.viewport().mapToGlobal(point))
+        if chosen == inspect:
+            self.window.inspect_selected()
+        elif chosen == create:
+            self._create_selected()
+
+    def _create_selected(self):
+        record = self.selected_record()
+        if record is None:
+            return
+        try:
+            result = sync.create_tool_from_catalog(
+                self._tools_dir(), self.client, record, name=None,
+                log=lambda m: App.Console.PrintMessage("Smooth: %s\n" % m))
+        except SmoothError as e:
+            self.window.refresh_api_log()
+            QtGui.QMessageBox.warning(self, "Smooth", str(e))
+            self._notify("✗ %s" % e)
+            return
+        self.window.refresh_api_log()
+        self._notify("Created '%s' from catalog (unbound). Reload the CAM tool "
+                     "library to see it in the editor." % result["basename"])
+        self.refresh()

--- a/freecad/Smooth/client.py
+++ b/freecad/Smooth/client.py
@@ -125,6 +125,20 @@ class SmoothApi(loobric.Client):
     def delete_instance(self, record_id):
         return self.delete_tool_record(record_id)
 
+    # -- ToolCatalogRecords (browse + create-from) — M2 --------------------
+
+    def list_catalogs(self):
+        """The catalog records available to browse (ToolCatalogRecords)."""
+        return self.list_catalog_records()
+
+    def get_catalog(self, record_id):
+        return self.get_catalog_record(record_id)
+
+    def create_from_catalog(self, catalog_id, name=None):
+        """Create a new UNBOUND instance from a catalog type (the catalog->
+        instance door). ``name`` overrides the copied catalog name when given."""
+        return self.create_instance_from_catalog(catalog_id, name=name)
+
     # -- ToolSets (one per .fctl) — sync lane -------------------------------
 
     def list_sets(self):

--- a/freecad/Smooth/client.py
+++ b/freecad/Smooth/client.py
@@ -37,7 +37,7 @@ NotFound = loobric.NotFound
 # This client's identity (the `clients` map key) and software version, stamped on
 # every section write; and the actor on human-initiated operator-lane acts.
 CLIENT_NAME = mapping.CLIENT_NAME        # "freecad"
-CLIENT_VERSION = "0.2.1"
+CLIENT_VERSION = "0.3.0"
 HUMAN_ACTOR = "human@freecad"
 
 # Public resource tokens for the generic canonical doors (assert / section sync).

--- a/freecad/Smooth/loobric.py
+++ b/freecad/Smooth/loobric.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# PYTHON_ARGCOMPLETE_OK
 # MIT License
 # Copyright (c) 2025 sliptonic
 # SPDX-License-Identifier: MIT
@@ -320,6 +321,39 @@ class Client:
         return self._call("POST", f"/tool-set-records/{set_id}/members",
                           body={"members": members, "actor": actor})
 
+    def _member_payload(self, set_id: str) -> List[Dict[str, Any]]:
+        """Current membership as the `{tool_record_id, number}` payload the
+        members door expects (number is the bare int, or None for unknown)."""
+        rec = self.get_tool_set(set_id)
+        out = []
+        for m in (rec.get("canonical") or {}).get("members") or []:
+            num = m.get("number")
+            out.append({"tool_record_id": m["tool_record_id"],
+                        "number": num.get("value") if isinstance(num, dict) else num})
+        return out
+
+    def add_to_set(self, set_id: str, tool_record_ids: List[str],
+                   actor: str = "human@cli") -> Dict[str, Any]:
+        """Add tool record(s) to a set, keeping existing members and their
+        numbers. Tools already in the set are skipped — membership is a set, not
+        a bag. Read-modify-write over the replace-only members door."""
+        members = self._member_payload(set_id)
+        have = {m["tool_record_id"] for m in members}
+        for tid in tool_record_ids:
+            if tid not in have:
+                members.append({"tool_record_id": tid, "number": None})
+                have.add(tid)
+        return self.set_members(set_id, members, actor)
+
+    def remove_from_set(self, set_id: str, tool_record_ids: List[str],
+                        actor: str = "human@cli") -> Dict[str, Any]:
+        """Remove tool record(s) from a set, keeping the rest. Read-modify-write
+        over the replace-only members door."""
+        drop = set(tool_record_ids)
+        members = [m for m in self._member_payload(set_id)
+                   if m["tool_record_id"] not in drop]
+        return self.set_members(set_id, members, actor)
+
     # -- machines ------------------------------------------------------------
     def list_machines(self) -> List[Dict[str, Any]]:
         return self._call("GET", "/machine-records").get("items", [])
@@ -449,6 +483,12 @@ class Client:
     def whoami(self) -> Dict[str, Any]:
         return self._call("GET", "/auth/me")
 
+    def server_version(self) -> Dict[str, Any]:
+        """The server's build identity ({version, commit}). Unauthenticated, so
+        it works before login; a NotFound means the server predates the endpoint
+        (an older build)."""
+        return self._call("GET", "/version", require_auth=False)
+
     def change_password(self, current_password: str, new_password: str) -> Dict[str, Any]:
         return self._call("POST", "/auth/change-password",
                           body={"current_password": current_password,
@@ -481,8 +521,37 @@ class Client:
     def get_catalog_record(self, record_id: str) -> Dict[str, Any]:
         return self._call("GET", f"/tool-catalog-records/{record_id}")
 
-    def create_catalog_record(self, **section) -> Dict[str, Any]:
-        return self._call("POST", "/tool-catalog-records", body=dict(section))
+    def create_catalog_record(self, source: str,
+                              fields: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Seeded, atomic catalog-record create. `source` is the declared actor —
+        the server stamps `asserted:<source>` on every field; the client never
+        writes provenance. `fields` carries the nominal {value, unit} leaves
+        (name/manufacturer/product_code + optional geometry/item_type)."""
+        return self._call("POST", "/tool-catalog-records",
+                          body={"actor": source, **(fields or {})})
+
+    def create_instance_from_catalog(self, catalog_id: str,
+                                     name: Optional[str] = None,
+                                     qa: Optional[Dict[str, Any]] = None,
+                                     cert: Optional[str] = None) -> Dict[str, Any]:
+        """Create a new physical instance from a catalog type via the catalog->
+        instance door. The server stamps the catalog_type_id link as
+        asserted:<requester> and leaves the instance UNBOUND (a catalog is not a
+        machine position). `name` overrides the copied catalog name when given.
+
+        Optional manufacturer QA: `qa` is a geometry-shaped {value, unit} map and
+        `cert` its certificate/serial; the server stamps each measured field
+        observed:manufacturer@<serial> (the client never sends a raw source)."""
+        body: Dict[str, Any] = {}
+        if name is not None:
+            body["name"] = name
+        if qa is not None:
+            body["qa"] = qa
+        if cert is not None:
+            body["cert"] = cert
+        return self._call("POST",
+                          f"/tool-catalog-records/{catalog_id}/create-instance",
+                          body=body)
 
     def create_entry(self, machine_id: str, **section) -> Dict[str, Any]:
         return self._call("POST", "/tool-table-entry-records",
@@ -740,6 +809,65 @@ def list_tool_sets():
         print("=" * 80)
 
 
+def show_tool_set(set_handle):
+    """Show one tool set and its members: each member's number (with the source
+    that vouches for it), the tool it points at, and that tool's geometry."""
+    s = _resolve_tool_set(set_handle)
+    members = (s.get("canonical") or {}).get("members") or []
+    print(f"\nTool Set {_rid(s)}")
+    print("=" * 78)
+    print(f"  Name: {_cval(s, 'name') or '(unnamed)'}")
+    machine = _cval(s, "machine_id")
+    if machine:
+        mname = {_rid(m): _cval(m, "name") for m in _client().list_machines()}.get(machine)
+        print(f"  Machine: {mname or str(machine)[:8]} (member numbers inherited)")
+    else:
+        print("  Machine: not linked")
+    print(f"  Members: {len(members)}")
+    if not members:
+        print("  (none yet — add tools with 'loobric add-to-set')")
+        print("=" * 78)
+        return
+    tools = {_rid(t): t for t in _client().list_tool_records()}
+
+    def _num(m):
+        v = (m.get("number") or {}).get("value")
+        return v if v is not None else float("inf")
+
+    for m in sorted(members, key=_num):
+        tid = m.get("tool_record_id")
+        num = m.get("number") or {}
+        t = tools.get(tid)
+        tname = (_cval(t, "name") if t else None) or (str(tid)[:8] if tid else "?")
+        ndisp = f"T{num['value']}" if num.get("value") is not None else "(no #)"
+        dia = _cval(t, "geometry", "diameter") if t else None
+        extra = f"  ⌀{dia}" if dia is not None else ""
+        print(f"  {ndisp:>6}  {tname}{extra}  [{num.get('source', 'unknown')}]")
+    print("=" * 78)
+
+
+def add_to_set(set_handle, tools):
+    """Add one or more tools to a tool set (existing members are kept)."""
+    s = _resolve_tool_set(set_handle)
+    recs = [_resolve_record(t) for t in tools]
+    updated = _client().add_to_set(_rid(s), [_rid(r) for r in recs])
+    n = len((updated.get("canonical") or {}).get("members") or [])
+    label = _cval(s, "name") or str(_rid(s))[:8]
+    names = ", ".join(_cval(r, "name") or str(_rid(r))[:8] for r in recs)
+    print(f"✓ Added {len(recs)} tool(s) to '{label}' — {names}. Now {n} member(s).")
+
+
+def remove_from_set(set_handle, tools):
+    """Remove one or more tools from a tool set (the rest are kept)."""
+    s = _resolve_tool_set(set_handle)
+    recs = [_resolve_record(t) for t in tools]
+    updated = _client().remove_from_set(_rid(s), [_rid(r) for r in recs])
+    n = len((updated.get("canonical") or {}).get("members") or [])
+    label = _cval(s, "name") or str(_rid(s))[:8]
+    names = ", ".join(_cval(r, "name") or str(_rid(r))[:8] for r in recs)
+    print(f"✓ Removed {len(recs)} tool(s) from '{label}' — {names}. Now {n} member(s).")
+
+
 def list_pending():
     """List inbox items awaiting review (binding proposals).
 
@@ -886,6 +1014,43 @@ def _resolve_record(prefix: str) -> Dict[str, Any]:
 
 def _resolve_tool_set(prefix: str) -> Dict[str, Any]:
     return _match_id(_client().list_tool_sets(), prefix, "tool set")
+
+
+def _resolve_catalog(handle: str) -> Dict[str, Any]:
+    """Resolve a catalog record by id / unique id-prefix / name / product_code
+    (same shape as the other resolvers; on ambiguity it prints the candidates).
+    A catalog record carries a manufacturer product_code, so humans reach for it
+    as readily as the id or name — all three are first-class handles here."""
+    items = _client().list_catalog_records()
+    # An exact id, name, or product_code wins outright.
+    for keyfn in (lambda r: _rid(r),
+                  lambda r: _cval(r, "name"),
+                  lambda r: _cval(r, "product_code")):
+        exact = [r for r in items if keyfn(r) == handle]
+        if len(exact) == 1:
+            return exact[0]
+        if len(exact) > 1:
+            _ambiguous_catalog(handle, exact)
+    # Otherwise a unique prefix on the id, the name, or the product_code.
+    matches = [r for r in items
+               if str(_rid(r) or "").startswith(handle)
+               or str(_cval(r, "name") or "").startswith(handle)
+               or str(_cval(r, "product_code") or "").startswith(handle)]
+    if not matches:
+        print(f"Error: no catalog record matches '{handle}'", file=sys.stderr)
+        sys.exit(1)
+    if len(matches) > 1:
+        _ambiguous_catalog(handle, matches)
+    return matches[0]
+
+
+def _ambiguous_catalog(handle: str, candidates: List[Dict[str, Any]]) -> None:
+    print(f"Error: '{handle}' is ambiguous ({len(candidates)} catalog records):",
+          file=sys.stderr)
+    for c in candidates:
+        print(f"  {str(_rid(c))[:8]}  {_cval(c, 'name') or ''}  "
+              f"{_cval(c, 'product_code') or ''}".rstrip(), file=sys.stderr)
+    sys.exit(1)
 
 
 def _resolve_entry(machine: Dict[str, Any], tool_number: int) -> Dict[str, Any]:
@@ -1046,6 +1211,32 @@ def unbind_entry(machine_id: str, tool_number: int):
     print(f"✓ Unbound T{tool_number} @ {m_name}. The entry keeps its data.")
 
 
+def create_record(args):
+    """Context-aware create-record: from a machine entry (-> BOUND instance) or
+    from a catalog record (-> UNBOUND instance). The two paths are mutually
+    exclusive; the outcome message names which one ran."""
+    qa_path = getattr(args, "qa", None)
+    cert = getattr(args, "cert", None)
+    if getattr(args, "from_catalog", None):
+        if args.machine or args.tool_number is not None:
+            print("Error: --from-catalog cannot be combined with MACHINE/TOOL_NUMBER",
+                  file=sys.stderr)
+            sys.exit(1)
+        create_record_from_catalog(args.from_catalog, args.name,
+                                   qa_path=qa_path, cert=cert)
+    else:
+        if qa_path or cert:
+            print("Error: --qa/--cert are only valid with --from-catalog "
+                  "(manufacturer QA is recorded when creating from a catalog record)",
+                  file=sys.stderr)
+            sys.exit(1)
+        if not args.machine or args.tool_number is None:
+            print("Error: create-record needs MACHINE TOOL_NUMBER (entry form) "
+                  "or --from-catalog CATALOG", file=sys.stderr)
+            sys.exit(1)
+        create_record_from_entry(args.machine, args.tool_number, args.name)
+
+
 def create_record_from_entry(machine_id: str, tool_number: int, name: str = None):
     """Mint a new instance record from a entry's observations and bind it, in one
     step. The bind endpoint mints a new instance when no instance_id is given."""
@@ -1057,6 +1248,47 @@ def create_record_from_entry(machine_id: str, tool_number: int, name: str = None
     rec_id = str(bound or "")[:8]
     print(f"✓ Created a record from T{tool_number} @ {m_name} and bound it "
           f"(record {rec_id}).")
+
+
+def create_record_from_catalog(catalog_handle: str, name: str = None,
+                               qa_path: str = None, cert: str = None):
+    """Create a new UNBOUND instance from a catalog record (the catalog->instance
+    door). The server stamps the catalog_type_id link as asserted:<requester>;
+    the instance is left unbound (it sits in no machine entry). The name defaults
+    to the catalog record's name unless --name overrides it.
+
+    Optional manufacturer QA: --qa is a geometry-shaped JSON file ({diameter:
+    {value, unit}, ...}) and --cert its certificate/serial. --cert is required
+    iff --qa is given; the server stamps each measured field
+    observed:manufacturer@<serial>."""
+    if qa_path and not cert:
+        print("Error: --qa requires --cert (the certificate/serial the QA "
+              "measurements are recorded against)", file=sys.stderr)
+        sys.exit(1)
+    if cert and not qa_path:
+        print("Error: --cert requires --qa (a certificate needs QA measurements "
+              "to certify)", file=sys.stderr)
+        sys.exit(1)
+    qa = None
+    if qa_path:
+        with open(qa_path) as f:
+            text = f.read().strip()
+        try:
+            qa = json.loads(text) if text else {}
+        except json.JSONDecodeError as e:
+            print(f"Error: invalid JSON in --qa file: {e}", file=sys.stderr)
+            sys.exit(1)
+        if not isinstance(qa, dict):
+            print("Error: --qa JSON must be a geometry-shaped object", file=sys.stderr)
+            sys.exit(1)
+    catalog = _resolve_catalog(catalog_handle)
+    cat_name = _cval(catalog, "name")
+    rec = _client().create_instance_from_catalog(_rid(catalog), name=name,
+                                                 qa=qa, cert=cert)
+    inst_id = str(_rid(rec) or "")[:8]
+    qa_note = f" with manufacturer QA ({cert})" if qa else ""
+    print(f"✓ Created instance {inst_id} from {cat_name}{qa_note} — unbound "
+          f"(no machine entry yet).")
 
 
 def create_machine(name, controller=None):
@@ -1071,6 +1303,117 @@ def create_set(name):
     """Create a tool set and assert its name."""
     rec = _client().create_tool_set(name=name)
     print(f"✓ Created tool set '{name}' ({str(_rid(rec))[:8]}).")
+
+
+def _load_catalog_fields(file=None) -> Dict[str, Any]:
+    """Read the nominal-fields JSON for a catalog record: from --file, else from
+    stdin (the '-' convention). An empty/absent stream is an empty object — the
+    convenience flags may supply every field by hand. The JSON carries values +
+    units; provenance is never in it (the server stamps it from --source)."""
+    if file:
+        with open(file) as f:
+            text = f.read()
+    elif not sys.stdin.isatty():
+        text = sys.stdin.read()
+    else:
+        text = ""
+    text = text.strip()
+    if not text:
+        return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        print(f"Error: invalid JSON for catalog record: {e}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(data, dict):
+        print("Error: catalog record JSON must be an object", file=sys.stderr)
+        sys.exit(1)
+    return data
+
+
+def _flag_field(fields: Dict[str, Any], key: str, value: Any) -> None:
+    """A convenience flag supplies/overrides a top-level nominal field's value,
+    keeping any unit already present in the JSON."""
+    if value is None:
+        return
+    leaf = fields.get(key)
+    if isinstance(leaf, dict):
+        leaf["value"] = value
+    else:
+        fields[key] = {"value": value}
+
+
+def create_catalog_record(source, file=None, name=None, manufacturer=None,
+                          product_code=None, diameter=None, flutes=None):
+    """Create a catalog record (a ToolCatalogRecord) in one atomic, audited call.
+
+    Nominal fields arrive as JSON on stdin (the '-' convention) or via --file,
+    with thin convenience flags (--name/--manufacturer/--product-code/--diameter/
+    --flutes) for the by-hand case. --source is the declared actor; the server
+    stamps `asserted:<source>` on every field — the client never writes
+    provenance. name, manufacturer and product_code are required (the identity
+    floor)."""
+    fields = _load_catalog_fields(file)
+    _flag_field(fields, "name", name)
+    _flag_field(fields, "manufacturer", manufacturer)
+    _flag_field(fields, "product_code", product_code)
+    if diameter is not None:
+        fields.setdefault("geometry", {})["diameter"] = {"value": diameter, "unit": "mm"}
+    if flutes is not None:
+        fields.setdefault("geometry", {})["flutes"] = {"value": flutes}
+    rec = _client().create_catalog_record(source=source, fields=fields)
+    print(f"✓ Created catalog record '{_cval(rec, 'name')}' "
+          f"({str(_rid(rec))[:8]}). Every field carries source "
+          f"'asserted:{source}'.")
+
+
+def list_catalog_records():
+    """List the user's catalog records (ToolCatalogRecords)."""
+    items = _client().list_catalog_records()
+    if not items:
+        print("No catalog records found.")
+        return
+    print(f"\nCatalog Records ({len(items)}):")
+    print("=" * 78)
+    for c in items:
+        print(f"  ID: {_rid(c)}")
+        print(f"  Name: {_cval(c, 'name')}")
+        ident = "  ".join(p for p in (_cval(c, "manufacturer"),
+                                      _cval(c, "product_code")) if p)
+        if ident:
+            print(f"  {ident}")
+        dia = _cfield(c, "geometry", "diameter")
+        if dia.get("value") is not None:
+            print(f"  Geometry: ⌀{dia['value']}{dia.get('unit', '')}")
+        print("=" * 78)
+
+
+def _print_field(label, leaf, indent="  "):
+    """Show one canonical field with its provenance — value, optional unit, and
+    the source it came from (the whole point: fabrication stays visible)."""
+    value = leaf.get("value")
+    unit = leaf.get("unit")
+    disp = "—" if value is None else (f"{value} {unit}" if unit else f"{value}")
+    print(f"{indent}{label}: {disp}  [{leaf.get('source', '')}]")
+
+
+def show_catalog_record(catalog):
+    """Show one catalog record with full provenance — every field with its source."""
+    rec = _resolve_catalog(catalog)
+    canonical = rec.get("canonical") or {}
+    print(f"\nCatalog Record {_rid(rec)}")
+    print("=" * 78)
+    for key in ("name", "manufacturer", "product_code", "item_type"):
+        leaf = canonical.get(key)
+        if isinstance(leaf, dict) and "source" in leaf:
+            _print_field(key, leaf)
+    geometry = canonical.get("geometry") or {}
+    present = {k: v for k, v in geometry.items() if isinstance(v, dict)}
+    if present:
+        print("  geometry:")
+        for gkey, leaf in present.items():
+            _print_field(gkey, leaf, indent="    ")
+    print("=" * 78)
 
 
 def _parse_entry(spec):
@@ -1128,13 +1471,24 @@ def reset_account(assume_yes=False):
 
 
 def whoami():
-    """Show the authenticated account."""
-    me = _client().whoami()
-    print(f"  Email: {me.get('email')}")
-    print(f"  Role:  {me.get('role')}")
-    print(f"  Admin: {me.get('is_admin')}")
+    """Show which server we're talking to, the authenticated account, and the
+    server's build identity (the fastest 'is this the server/code I expect?'
+    check)."""
+    client = _client()
+    print(f"  Server: {client.base_url or '(none set)'}")
+    me = client.whoami()
+    print(f"  Email:  {me.get('email')}")
+    print(f"  Role:   {me.get('role')}")
+    print(f"  Admin:  {me.get('is_admin')}")
     if me.get("id"):
-        print(f"  ID:    {me.get('id')}")
+        print(f"  ID:     {me.get('id')}")
+    # Server build identity — an older server has no /version endpoint, which is
+    # itself the answer to "is it running my code?"
+    try:
+        v = client.server_version()
+        print(f"  Build:  {v.get('version', '?')} ({v.get('commit', '?')})")
+    except NotFound:
+        print("  Build:  unknown — older server with no /version endpoint")
 
 
 def list_audit(limit=50):
@@ -1271,6 +1625,12 @@ def main():
   loobric bind millstone 7 <record>     # or bind an existing record
   loobric unbind millstone 7
 
+  # Catalog records -> a physical instance (unbound: not in any machine yet)
+  loobric create-record --from-catalog B201            # by product code
+  loobric create-record --from-catalog B201 --name "1/4 downcut, lot 7"
+  loobric create-record --from-catalog B201 \\
+    --qa qa.json --cert "kennametal@SN12345"           # + manufacturer QA
+
   # Inspect
   loobric list-machines
   loobric list-tools
@@ -1389,6 +1749,17 @@ Environment Variables:
     )
     list_tool_sets_parser.set_defaults(func=lambda args: list_tool_sets())
 
+    # === show-tool-set ===
+    show_tool_set_parser = subparsers.add_parser(
+        "show-tool-set",
+        help="Show one tool set and its members",
+        description="Show a tool set's members — each member's number (with the "
+                    "source that vouches for it), the tool, and its geometry. SET "
+                    "resolves by id, name, or unique prefix.",
+    )
+    show_tool_set_parser.add_argument("set", help="Tool set id, name, or unique prefix")
+    show_tool_set_parser.set_defaults(func=lambda args: show_tool_set(args.set))
+
     # === link-machine ===
     link_parser = subparsers.add_parser(
         "link-machine",
@@ -1485,16 +1856,40 @@ Environment Variables:
 
     create_record_parser = subparsers.add_parser(
         "create-record",
-        help="Create a tool record from an entry and bind it in one step",
+        help="Create a tool instance — from an entry (bound) or a catalog (unbound)",
+        description="Two context-aware forms. MACHINE TOOL_NUMBER creates an "
+                    "instance from a machine entry and BINDS it to that position. "
+                    "--from-catalog creates an instance from a catalog record and "
+                    "leaves it UNBOUND (a catalog is not a machine position).",
     )
-    create_record_parser.add_argument("machine", help="Machine id or unique prefix")
-    create_record_parser.add_argument("tool_number", type=int, help="Tool number (e.g. 3)")
     create_record_parser.add_argument(
-        "--name", help="Name for the new record (defaults to the entry description)"
+        "machine", nargs="?", help="Machine id or unique prefix (entry form)"
     )
-    create_record_parser.set_defaults(
-        func=lambda args: create_record_from_entry(args.machine, args.tool_number, args.name)
+    create_record_parser.add_argument(
+        "tool_number", nargs="?", type=int, help="Tool number, e.g. 3 (entry form)"
     )
+    create_record_parser.add_argument(
+        "--from-catalog", metavar="CATALOG",
+        help="Create an UNBOUND instance from a catalog record "
+             "(id/prefix/name/product_code)",
+    )
+    create_record_parser.add_argument(
+        "--name",
+        help="Name for the new instance (entry form: defaults to the entry "
+             "description; catalog form: defaults to the catalog record's name)",
+    )
+    create_record_parser.add_argument(
+        "--qa", metavar="FILE",
+        help="Manufacturer QA: a geometry-shaped JSON file ({diameter:{value,"
+             "unit}, ...}) measured on the certified tool (catalog form only; "
+             "requires --cert)",
+    )
+    create_record_parser.add_argument(
+        "--cert",
+        help="Certificate/serial the --qa measurements are recorded against; the "
+             "server stamps them observed:manufacturer@<serial> (required iff --qa)",
+    )
+    create_record_parser.set_defaults(func=create_record)
 
     # === create-machine ===
     create_machine_parser = subparsers.add_parser(
@@ -1512,6 +1907,75 @@ Environment Variables:
     )
     create_set_parser.add_argument("name", help="Tool set name")
     create_set_parser.set_defaults(func=lambda args: create_set(args.name))
+
+    add_to_set_parser = subparsers.add_parser(
+        "add-to-set", help="Add one or more tools to a tool set",
+        description="Append tool record(s) to a set's membership. Existing "
+                    "members (and their numbers) are kept; a tool already in the "
+                    "set is skipped. SET and each TOOL resolve by id, name, or "
+                    "unique prefix.",
+    )
+    add_to_set_parser.add_argument("set", help="Tool set id, name, or unique prefix")
+    add_to_set_parser.add_argument("tool", nargs="+",
+                                   help="Tool record id(s), name(s), or unique prefix(es)")
+    add_to_set_parser.set_defaults(func=lambda args: add_to_set(args.set, args.tool))
+
+    remove_from_set_parser = subparsers.add_parser(
+        "remove-from-set", help="Remove one or more tools from a tool set",
+        description="Remove tool record(s) from a set's membership; the rest are "
+                    "kept. SET and each TOOL resolve by id, name, or unique prefix.",
+    )
+    remove_from_set_parser.add_argument("set", help="Tool set id, name, or unique prefix")
+    remove_from_set_parser.add_argument("tool", nargs="+",
+                                        help="Tool record id(s), name(s), or unique prefix(es)")
+    remove_from_set_parser.set_defaults(
+        func=lambda args: remove_from_set(args.set, args.tool))
+
+    # === create-catalog-record ===
+    create_catalog_parser = subparsers.add_parser(
+        "create-catalog-record",
+        help="Create a catalog record from JSON (stdin/--file) or flags",
+        description="Create a ToolCatalogRecord in one atomic, audited call. "
+                    "Nominal fields come from JSON on stdin (the '-' convention) "
+                    "or --file, plus convenience flags. --source is the declared "
+                    "actor; the server stamps 'asserted:<source>' on every field.",
+    )
+    create_catalog_parser.add_argument(
+        "input", nargs="?",
+        help="'-' to read JSON from stdin (default when piped), or a path",
+    )
+    create_catalog_parser.add_argument(
+        "--source", required=True,
+        help="Declared actor, e.g. manufacturer:kennametal "
+             "(server stamps asserted:<source> on every field)",
+    )
+    create_catalog_parser.add_argument("--file", help="Read nominal fields JSON from this file")
+    create_catalog_parser.add_argument("--name", help="Catalog record name")
+    create_catalog_parser.add_argument("--manufacturer", help="Manufacturer")
+    create_catalog_parser.add_argument("--product-code", help="Manufacturer product code")
+    create_catalog_parser.add_argument("--diameter", type=float, help="Nominal diameter (mm)")
+    create_catalog_parser.add_argument("--flutes", type=int, help="Flute count")
+    create_catalog_parser.set_defaults(func=lambda args: create_catalog_record(
+        source=args.source,
+        file=args.file or (args.input if args.input and args.input != "-" else None),
+        name=args.name, manufacturer=args.manufacturer,
+        product_code=args.product_code, diameter=args.diameter, flutes=args.flutes,
+    ))
+
+    # === list-catalog-records ===
+    list_catalog_parser = subparsers.add_parser(
+        "list-catalog-records", help="List catalog records (ToolCatalogRecords)"
+    )
+    list_catalog_parser.set_defaults(func=lambda _: list_catalog_records())
+
+    # === show-catalog-record ===
+    show_catalog_parser = subparsers.add_parser(
+        "show-catalog-record", help="Show one catalog record with provenance"
+    )
+    show_catalog_parser.add_argument(
+        "catalog", help="Catalog record id, unique prefix, name, or product_code"
+    )
+    show_catalog_parser.set_defaults(func=lambda args: show_catalog_record(args.catalog))
 
     # === push ===
     push_parser = subparsers.add_parser(
@@ -1583,6 +2047,16 @@ Environment Variables:
         description="End the current session (clears session cookie)."
     )
     logout_parser.set_defaults(func=lambda _: logout())
+
+    # Optional shell tab-completion. argcomplete is NOT a dependency — this file
+    # stays stdlib-only and fully runnable without it; when argcomplete is
+    # present and registered (see README/CLI.md), it wires up completion for
+    # every subcommand and flag derived from this parser. No-op when absent.
+    try:
+        import argcomplete
+        argcomplete.autocomplete(parser)
+    except ImportError:
+        pass
 
     # Parse args
     args = parser.parse_args()

--- a/freecad/Smooth/mapping.py
+++ b/freecad/Smooth/mapping.py
@@ -315,6 +315,40 @@ def instance_to_fctb(record):
     return doc
 
 
+def catalog_to_fctb(catalog_record, instance_record):
+    """Synthesize a .fctb for a tool just created from a catalog record.
+
+    Two sectioned records meet here:
+
+    - ``catalog_record`` (a ToolCatalogRecord) holds the usable NOMINAL geometry
+      and name in its ``canonical`` section — the shape and dimensions the local
+      bit must take.
+    - ``instance_record`` (the ToolInstanceRecord the catalog->instance door just
+      created) carries the new ``internal.id`` the local tool must track, but its
+      OWN ``canonical.geometry`` is deliberately EMPTY: at creation the physical
+      tool has not been measured, so its measured geometry is unknown. The usable
+      shape therefore has to come from the catalog's nominal geometry, not the
+      instance.
+
+    Built by reusing :func:`instance_to_fctb` on a merged record: the instance's
+    ``internal`` (so ``smooth.record_id`` is the NEW instance's id), the catalog's
+    canonical geometry (the nominal shape + dimensions), and the instance's own
+    name when it set one (a ``--name`` override) else the catalog's name. Empty
+    ``clients`` — there is no prior .fctb to preserve. Pure; inputs untouched."""
+    catalog = catalog_record or {}
+    instance = instance_record or {}
+    merged_canonical = copy.deepcopy(catalog.get("canonical") or {})
+    inst_name = (instance.get("canonical") or {}).get("name")
+    if _field_value(inst_name) is not None:
+        merged_canonical["name"] = copy.deepcopy(inst_name)
+    merged = {
+        "internal": instance.get("internal") or {},
+        "canonical": merged_canonical,
+        "clients": {},
+    }
+    return instance_to_fctb(merged)
+
+
 # ---------------------------------------------------------------------------
 # .fctl <-> ToolSet
 # ---------------------------------------------------------------------------

--- a/freecad/Smooth/sync.py
+++ b/freecad/Smooth/sync.py
@@ -559,6 +559,63 @@ def plan_sync(tools_dir, client, log=lambda msg: None):
     return {"items": items, "errors": errors}
 
 
+def create_tool_from_catalog(tools_dir, client, catalog_record, name=None,
+                             log=lambda msg: None):
+    """Create a tool from a catalog record (the M2 catalog->instance flow).
+
+    Two effects, in order:
+
+    1. create an UNBOUND server instance from the catalog type
+       (``create_instance_from_catalog`` — a catalog is not a machine position,
+       so nothing is bound);
+    2. immediately materialize a local ``.fctb`` in ``<tools_dir>/Bit/``,
+       pre-filled from the CATALOG's nominal geometry and linked to the new
+       instance (the instance's own measured geometry is empty by M2 design —
+       see :func:`mapping.catalog_to_fctb`).
+
+    Follows the ``pull_bit`` materialize pattern (same path/dedup/state-journal
+    helpers): the filename stem comes from the instance's ``client_item_id`` (or
+    a slug of the instance/catalog name), an existing file is disambiguated with
+    the record's short id, and the sync journal learns ``records[rid] = basename``
+    so the next sync UPDATES this record rather than re-creating it.
+
+    Returns ``{"path", "instance", "basename"}``.
+    """
+    catalog_id = _record_id(catalog_record)
+    inst = client.create_instance_from_catalog(catalog_id, name=name)
+    rid = _record_id(inst)
+    doc = mapping.catalog_to_fctb(catalog_record, inst)
+
+    bit_dir = os.path.join(tools_dir, "Bit")
+    os.makedirs(bit_dir, exist_ok=True)
+    cii = _client_item_id(inst) or ""
+    stem = cii.rsplit(".fctb", 1)[0] or _slug(
+        _record_name(inst) or _record_name(catalog_record) or "tool")
+    path = os.path.join(bit_dir, stem + ".fctb")
+    if os.path.exists(path):
+        path = os.path.join(bit_dir, "%s_%s.fctb" % (stem, rid[:8]))
+    _write_json(path, doc)
+    basename = os.path.basename(path)
+
+    # Write FreeCAD's client section (the lossless .fctb) back to the instance,
+    # establishing the sync base so this freshly-created tool lands SYNCED rather
+    # than as a no-base "conflict" on the next plan. Only the section is written —
+    # NOT the geometry asserts: the instance's canonical geometry stays
+    # deliberately empty (the nominal geometry is reachable through the catalog
+    # link), exactly as the server's create-from-catalog leaves it.
+    sections = mapping.record_to_instance_sections(doc, client_item_id=basename)
+    client.put_instance_section(rid, sections.data, sections.client_item_id)
+
+    state = _load_sync_state(tools_dir)
+    state["records"][rid] = basename
+    _save_sync_state(tools_dir, state)
+
+    log("CREATE from catalog '%s' -> %s [%s] (record %s, unbound, synced)"
+        % (_record_name(catalog_record) or "?", basename,
+           doc.get("shape-type", "?"), rid[:8]))
+    return {"path": path, "instance": inst, "basename": basename}
+
+
 class SyncApplyError(Exception):
     """Apply-time failure for one item (others proceed)."""
 

--- a/freecad/Smooth/viewmodel.py
+++ b/freecad/Smooth/viewmodel.py
@@ -69,6 +69,59 @@ def fmt_dia(value):
     return "%.3g mm" % value if isinstance(value, (int, float)) else "—"
 
 
+# The honest-sparse marker: a field we don't have renders as this, never as a
+# blank cell or a fabricated zero (the provenance discipline, made visible).
+MISSING = "—"
+
+
+# ---------------------------------------------------------------------------
+# Catalog tab — the browse table (one row per ToolCatalogRecord)
+# ---------------------------------------------------------------------------
+
+def _catalog_text(field):
+    """Display a catalog Field's value, or the honest-sparse marker when it is
+    absent — never a blank, never a coerced 0."""
+    value = field_value(field)
+    return MISSING if value in (None, "") else str(value)
+
+
+def _catalog_geometry(record):
+    """A short geometry summary for a catalog row: the nominal diameter (with
+    unit when present), else the shape, else the honest-sparse marker."""
+    dia = canonical(record, "geometry", "diameter")
+    value = field_value(dia)
+    if value is not None:
+        unit = dia.get("unit") if isinstance(dia, dict) else None
+        return "⌀%s%s" % (value, unit or "")
+    shape = field_value(canonical(record, "geometry", "shape"))
+    return str(shape) if shape else MISSING
+
+
+def catalog_rows(catalog_records):
+    """Render model for the Catalog browse table — one row per catalog record.
+
+    Each row is ``{id, name, manufacturer, product_code, geometry, source}``:
+    ``geometry`` is the nominal-diameter summary and ``source`` is the provenance
+    of the name (falling back to the diameter's), so where a catalog's facts came
+    from stays visible — mirroring the web. Honest-sparse: a missing field is the
+    :data:`MISSING` marker, never a blank or a fabricated zero. Pure: the widget
+    only renders this."""
+    rows = []
+    for record in catalog_records or []:
+        name_field = canonical(record, "name")
+        dia_field = canonical(record, "geometry", "diameter")
+        rows.append({
+            "id": (record.get("internal") or {}).get("id"),
+            "name": _catalog_text(name_field),
+            "manufacturer": _catalog_text(canonical(record, "manufacturer")),
+            "product_code": _catalog_text(canonical(record, "product_code")),
+            "geometry": _catalog_geometry(record),
+            "source": field_source(name_field) or field_source(dia_field)
+                      or MISSING,
+        })
+    return rows
+
+
 # ---------------------------------------------------------------------------
 # Status model: Existence × Sync, kept deliberately separate
 # ---------------------------------------------------------------------------

--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,7 @@ Requirements:
 - FreeCAD 1.1 or later with the CAM workbench
 - A Smooth server (self-hosted or hosted) - see https://loobric.com
 - Standard library only: no extra Python packages</description>
-  <version>0.2.1</version>
+  <version>0.3.0</version>
   <date>2026-06-20</date>
   <maintainer email="sliptonic@gmail.com">Brad Collette</maintainer>
   <license file="LICENSE">MIT</license>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,9 @@ class FakeServer:
     def __init__(self):
         self.instances = {}   # id -> sectioned record
         self.sets = {}        # id -> sectioned record
+        self.catalogs = {}    # id -> sectioned ToolCatalogRecord
         self._n = 0
+        self._seed_catalog()
 
     def _next(self, prefix):
         self._n += 1
@@ -48,6 +50,13 @@ class FakeServer:
         return {"internal": {"id": rid, "version": 1,
                              "created_at": "t0", "updated_at": "t0"},
                 "canonical": {}, "clients": {}}
+
+    @staticmethod
+    def _field(value, source="asserted:human@web", unit=None):
+        f = {"value": value, "source": source}
+        if unit is not None:
+            f["unit"] = unit
+        return f
 
     @staticmethod
     def _section(client_version, client_item_id, data):
@@ -91,6 +100,53 @@ class FakeServer:
     def delete_instance(self, record_id):
         self.instances.pop(record_id, None)
         return {"deleted": record_id}
+
+    # -- ToolCatalogRecords (M2: browse + create-instance) --------------------
+
+    def _seed_catalog(self):
+        """One catalog record to browse from: a manufacturer-identified type with
+        nominal name/manufacturer/product_code and a diameter + shape."""
+        cid = self._next("cat")
+        self.catalogs[cid] = {
+            "internal": {"id": cid, "version": 1,
+                         "created_at": "t0", "updated_at": "t0"},
+            "canonical": {
+                "name": self._field('1/4" Downcut'),
+                "manufacturer": self._field("Acme Tools"),
+                "product_code": self._field("B201"),
+                "geometry": {
+                    "shape": self._field("endmill"),
+                    "diameter": self._field(6.35, unit="mm"),
+                    "flutes": self._field(2),
+                },
+            },
+            "clients": {},
+        }
+
+    def list_catalog_records(self):
+        return list(self.catalogs.values())
+
+    def get_catalog_record(self, record_id):
+        return self.catalogs[record_id]
+
+    def create_instance_from_catalog(self, catalog_id, name=None):
+        """Mint an UNBOUND instance from a catalog type. The catalog link is
+        stamped canonical (asserted), the name copies the catalog's (or the
+        override), and measured ``geometry`` is left EMPTY — the M2 contract: a
+        just-created physical tool has not been measured, so its usable nominal
+        geometry has to come from the catalog record, not the instance."""
+        catalog = self.catalogs[catalog_id]
+        rid = self._next("rec")
+        rec = self._blank(rid)
+        cat_name = (catalog["canonical"].get("name") or {}).get("value")
+        _set_path(rec["canonical"], "catalog_type_id",
+                  {"value": catalog_id, "source": "asserted:human@freecad"})
+        _set_path(rec["canonical"], "name",
+                  {"value": name if name is not None else cat_name,
+                   "source": "asserted:human@freecad"})
+        rec["canonical"]["geometry"] = {}        # measured geometry unknown
+        self.instances[rid] = rec
+        return rec
 
     # -- ToolSets -------------------------------------------------------------
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,115 @@
+# MIT License
+# Copyright (c) 2025 sliptonic
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for the M2 catalog flow: ``sync.create_tool_from_catalog`` (smooth-core's
+catalog->instance feature, FreeCAD half).
+
+The contract under test, exercised against the in-memory sectioned ``FakeServer``
+(conftest), which seeds one ToolCatalogRecord:
+
+- creating from a catalog record mints an UNBOUND server instance AND materializes
+  a local ``.fctb`` in ``Bit/`` linked to that NEW instance (smooth.record_id);
+- the local tool is pre-filled from the CATALOG's nominal geometry (the instance's
+  own measured geometry is empty by M2 design);
+- the sync journal learns the record so the next sync updates, not re-creates;
+- a second create from the same catalog produces a DISTINCT file (dedup suffix)
+  and a distinct server instance;
+- a name override is honored.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from freecad.Smooth import sync
+from conftest import FakeServer
+
+
+def read(p):
+    return json.loads(Path(p).read_text())
+
+
+@pytest.mark.unit
+def test_create_tool_from_catalog_writes_linked_fctb(tools_dir):
+    server = FakeServer()
+    catalog = server.list_catalog_records()[0]
+
+    result = sync.create_tool_from_catalog(str(tools_dir), server, catalog)
+
+    # (1) an instance now exists on the server with empty canonical geometry
+    #     (unmeasured — nominal geometry is reachable through the catalog link),
+    #     and FreeCAD's client section IS written so the new tool lands SYNCED
+    #     (the sync base) rather than as a no-base "conflict" on the next plan.
+    inst_id = result["instance"]["internal"]["id"]
+    assert inst_id in server.instances
+    assert server.instances[inst_id]["canonical"]["geometry"] == {}  # unmeasured
+    assert "freecad" in server.instances[inst_id]["clients"]         # sync base written
+    plan = sync.plan_sync(str(tools_dir), server)
+    item = next(i for i in plan["items"]
+                if (i.get("record") or {}).get("internal", {}).get("id") == inst_id)
+    assert item["action"] == "unchanged"                             # synced, not a conflict
+
+    # (2) the .fctb landed in Bit/, linked to the NEW instance, with the
+    #     catalog's nominal geometry (not the instance's empty geometry)
+    path = Path(result["path"])
+    assert path.parent.name == "Bit" and path.exists()
+    doc = read(path)
+    assert doc["smooth"]["record_id"] == inst_id
+    assert doc["shape"] == "endmill.fcstd"
+    assert doc["parameter"]["Diameter"] == "6.35 mm"
+    assert doc["parameter"]["Flutes"] == 2
+
+    # (3) the sync journal tracks it (so the next sync UPDATES, not re-creates)
+    state = read(tools_dir / sync.STATE_BASENAME)
+    assert state["records"][inst_id] == result["basename"]
+
+
+@pytest.mark.unit
+def test_second_create_from_same_catalog_is_distinct(tools_dir):
+    """Two creates from the same catalog record yield two distinct files and two
+    distinct server instances (the dedup suffix, mirroring pull_bit)."""
+    server = FakeServer()
+    catalog = server.list_catalog_records()[0]
+
+    first = sync.create_tool_from_catalog(str(tools_dir), server, catalog)
+    second = sync.create_tool_from_catalog(str(tools_dir), server, catalog)
+
+    assert first["path"] != second["path"]
+    assert first["basename"] != second["basename"]
+    assert Path(first["path"]).exists() and Path(second["path"]).exists()
+    assert (first["instance"]["internal"]["id"]
+            != second["instance"]["internal"]["id"])
+    assert len(server.instances) == 2
+
+
+@pytest.mark.unit
+def test_create_tool_from_catalog_honors_name_override(tools_dir):
+    server = FakeServer()
+    catalog = server.list_catalog_records()[0]
+
+    result = sync.create_tool_from_catalog(str(tools_dir), server, catalog,
+                                           name="Special lot 7")
+    doc = read(result["path"])
+    assert doc["name"] == "Special lot 7"
+    assert doc["parameter"]["Diameter"] == "6.35 mm"   # geometry still catalog's
+
+
+@pytest.mark.unit
+def test_created_instance_is_tracked_and_matched_by_next_plan(tools_dir):
+    """The new instance is journaled and re-adopted by the next plan via the
+    written-back smooth.record_id — it is matched to its file (not seen as a
+    duplicate 'new_local' or a phantom 'deleted_local'), so a later sync acts on
+    the one record. (Its geometry is reconciled like any other bit; M2 does not
+    push the instance's measured geometry.)"""
+    server = FakeServer()
+    catalog = server.list_catalog_records()[0]
+    result = sync.create_tool_from_catalog(str(tools_dir), server, catalog)
+    inst_id = result["instance"]["internal"]["id"]
+
+    plan = sync.plan_sync(str(tools_dir), server)
+    item = next(i for i in plan["items"]
+                if (i.get("record") or {}).get("internal", {}).get("id") == inst_id)
+    assert item["path"] is not None                    # matched to its file
+    assert item["action"] not in ("new_local", "new_server", "deleted_local")

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import pytest
 
 from freecad.Smooth.mapping import (
-    record_to_instance_sections, instance_to_fctb,
+    record_to_instance_sections, instance_to_fctb, catalog_to_fctb,
     fctl_to_set_sections, set_to_fctl,
     fctb_record_id, fctl_record_id,
     parse_quantity, format_quantity,
@@ -321,6 +321,83 @@ def test_matching_shape_preserves_verbatim_base():
     doc = instance_to_fctb(record)
     assert doc["shape"] == "v-bit.fcstd"
     assert doc["parameter"]["CuttingEdgeAngle"] == "30 °"   # untouched
+
+
+# ---------------------------------------------------------------------------
+# catalog -> .fctb (M2: create-tool-from-catalog)
+# ---------------------------------------------------------------------------
+
+def _catalog_record(record_id="cat-1", name='1/4" Downcut', shape="endmill",
+                    diameter=6.35, flutes=2):
+    """A ToolCatalogRecord the way the server returns it: nominal name/geometry
+    as provenance-tagged Fields."""
+    return {
+        "internal": {"id": record_id, "version": 1},
+        "canonical": {
+            "name": field(name),
+            "manufacturer": field("Acme Tools"),
+            "product_code": field("B201"),
+            "geometry": {"shape": field(shape),
+                         "diameter": field(diameter, unit="mm"),
+                         "flutes": field(flutes)},
+        },
+        "clients": {},
+    }
+
+
+def _instance_from_catalog(record_id="rec-9", catalog_id="cat-1", name=None):
+    """The UNBOUND instance the catalog->instance door mints: the catalog link is
+    canonical, the name copies (or overrides) the catalog's, and measured
+    geometry is EMPTY (the M2 contract — geometry must come from the catalog)."""
+    return {
+        "internal": {"id": record_id, "version": 1},
+        "canonical": {"catalog_type_id": field(catalog_id),
+                      "name": field(name if name is not None else '1/4" Downcut'),
+                      "geometry": {}},
+        "clients": {},
+    }
+
+
+@pytest.mark.unit
+def test_catalog_to_fctb_carries_catalog_geometry_and_stamps_instance_id():
+    """The synthesized .fctb takes its shape + dimensions from the CATALOG's
+    nominal geometry, but its identity (smooth.record_id) from the new INSTANCE
+    — never the catalog id."""
+    catalog = _catalog_record()
+    instance = _instance_from_catalog(record_id="rec-9", catalog_id="cat-1")
+    doc = catalog_to_fctb(catalog, instance)
+    assert doc["shape"] == "endmill.fcstd"
+    assert doc["shape-type"] == "Endmill"
+    assert doc["parameter"]["Diameter"] == "6.35 mm"
+    assert doc["parameter"]["Flutes"] == 2
+    assert doc["name"] == '1/4" Downcut'
+    # the local tool tracks the INSTANCE, not the catalog
+    assert doc["smooth"]["record_id"] == "rec-9"
+
+
+@pytest.mark.unit
+def test_catalog_to_fctb_respects_instance_name_override():
+    """A --name override the instance carries wins over the catalog name; the
+    geometry still comes from the catalog."""
+    catalog = _catalog_record(name="Catalog Name", shape="drill", diameter=5.0)
+    instance = _instance_from_catalog(record_id="rec-2", name="Special lot 7")
+    doc = catalog_to_fctb(catalog, instance)
+    assert doc["name"] == "Special lot 7"
+    assert doc["shape"] == "drill.fcstd"          # geometry still from catalog
+    assert doc["parameter"]["Diameter"] == "5.00 mm"
+    assert doc["smooth"]["record_id"] == "rec-2"
+
+
+@pytest.mark.unit
+def test_catalog_to_fctb_does_not_mutate_inputs():
+    """Pure: neither the catalog nor the instance record is mutated."""
+    catalog = _catalog_record()
+    instance = _instance_from_catalog()
+    import copy as _copy
+    catalog_before = _copy.deepcopy(catalog)
+    instance_before = _copy.deepcopy(instance)
+    catalog_to_fctb(catalog, instance)
+    assert catalog == catalog_before and instance == instance_before
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_viewmodel.py
+++ b/tests/test_viewmodel.py
@@ -76,6 +76,47 @@ def test_row_status_info_and_is_exception():
     assert vm.row_status_info("future")["direction"] is None
 
 
+# -- catalog_rows ------------------------------------------------------------
+
+def _catalog(cid, name, manufacturer=None, product_code=None, diameter=None,
+             name_source="asserted:human@web"):
+    canon = {}
+    if name is not None:
+        canon["name"] = {"value": name, "source": name_source}
+    if manufacturer is not None:
+        canon["manufacturer"] = _field(manufacturer, "asserted:human@web")
+    if product_code is not None:
+        canon["product_code"] = _field(product_code, "asserted:human@web")
+    if diameter is not None:
+        canon["geometry"] = {"diameter": {"value": diameter, "unit": "mm",
+                                          "source": "asserted:human@web"}}
+    return {"internal": {"id": cid}, "canonical": canon, "clients": {}}
+
+
+@pytest.mark.unit
+def test_catalog_rows_extracts_fields_and_provenance():
+    [row] = vm.catalog_rows([
+        _catalog("c1", "1/4 Downcut", "Acme", "B201", 6.35)])
+    assert row["id"] == "c1"
+    assert row["name"] == "1/4 Downcut"
+    assert row["manufacturer"] == "Acme"
+    assert row["product_code"] == "B201"
+    assert "6.35" in row["geometry"] and "mm" in row["geometry"]
+    assert row["source"] == "asserted:human@web"      # provenance stays visible
+
+
+@pytest.mark.unit
+def test_catalog_rows_honest_sparse_no_blanks_as_zero():
+    """A sparse record renders missing fields as the marker, never blank, never a
+    fabricated 0 diameter."""
+    [row] = vm.catalog_rows([_catalog("c2", "Mystery")])  # no mfr/code/dia
+    assert row["name"] == "Mystery"
+    assert row["manufacturer"] == vm.MISSING
+    assert row["product_code"] == vm.MISSING
+    assert row["geometry"] == vm.MISSING               # not "0", not blank
+    assert "0" not in row["geometry"]
+
+
 # -- machine_tables ----------------------------------------------------------
 
 def _machine(mid, name, controller):


### PR DESCRIPTION
## M2 — FreeCAD catalog client

Adds a **Catalog tab**: browse the server's `ToolCatalogRecord`s and create a
tool from one. Create makes an unbound server instance and materializes a local
`.fctb` in the active library (pre-filled from the catalog's nominal geometry,
linked to the new instance), landing **synced**. Re-vendors `loobric.py` from
smooth-core 0.2.0.

Pure/tested core (`mapping.catalog_to_fctb`, `sync.create_tool_from_catalog`,
`viewmodel.catalog_rows`) + Qt `CatalogTab`. **96 tests pass** (87 + 9). See
`CHANGELOG.md` [0.3.0].

> The Qt tab is unverified in a live FreeCAD session (no headless FreeCAD); pure
> logic is fully tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)