### PR TITLE
M0: DCO enforcement + CONTRIBUTING (no CLA)

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,47 @@
+name: "DCO"
+
+# Enforces the Developer Certificate of Origin: every non-merge commit in a PR
+# must carry a `Signed-off-by:` trailer matching its author (use `git commit -s`).
+# Self-contained — no third-party app or action to install.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dco-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR commits
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify Signed-off-by on every commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          fail=0
+          # --no-merges: merge commits don't need a sign-off.
+          for sha in $(git rev-list --no-merges "$BASE_SHA".."$HEAD_SHA"); do
+            author="$(git show -s --format='%an <%ae>' "$sha")"
+            subject="$(git show -s --format='%s' "$sha")"
+            if ! git show -s --format='%B' "$sha" \
+                 | grep -qiE "^Signed-off-by: .+ <.+@.+>$"; then
+              echo "::error::Missing Signed-off-by on ${sha:0:8} \"$subject\" by $author"
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo ""
+            echo "One or more commits are missing a DCO sign-off."
+            echo "Add it by amending/rebasing with: git commit -s  (or: git rebase --signoff)"
+            echo "See CONTRIBUTING.md."
+            exit 1
+          fi
+          echo "All commits are signed off. Thanks!"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to smooth-freecad
+
+Thanks for your interest in contributing. This is a **reference client** for
+[Smooth Core](https://github.com/loobric/smooth-core), licensed **MIT**.
+
+## No CLA — just a DCO sign-off
+
+Unlike the AGPL-licensed `smooth-core` server (which requires a Contributor
+License Agreement), the MIT-licensed client repositories do **not** require a
+CLA. Instead, we use the **Developer Certificate of Origin (DCO)**: a simple,
+per-commit statement that you wrote the patch or otherwise have the right to
+contribute it under the project's license.
+
+You agree to the DCO (<https://developercertificate.org/>) by adding a
+`Signed-off-by` line to each commit:
+
+```
+git commit -s -m "Your message"
+```
+
+This appends a trailer using your configured `git` name and email:
+
+```
+Signed-off-by: Jane Developer <jane@example.com>
+```
+
+Use your real name and a reachable email. CI checks every commit in a pull
+request for this trailer and will fail the PR if any commit is missing it. To
+fix an existing branch:
+
+```
+git rebase --signoff main
+```
+
+## Development
+
+- [DEVELOPMENT.md](./DEVELOPMENT.md) — environment setup, repo layout, and tests.
+- [TECHNICAL.md](./TECHNICAL.md) — data model and how the FreeCAD formats map to
+  the Smooth schema.
+
+## Pull requests
+
+- Reference the issue your change addresses.
+- Keep changes focused and the test suite green.
+- Be respectful in discussion.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ HTTP traffic. Inspecting a record's raw JSON is a right-click action on any row.
 
 ## Links
 
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — how to contribute (MIT, DCO sign-off, no CLA)
 - [TECHNICAL.md](./TECHNICAL.md) — data model and how the FreeCAD formats map to
   the Smooth schema
 - [DEVELOPMENT.md](./DEVELOPMENT.md) — contributor guide, layout, and tests
@@ -165,7 +166,8 @@ HTTP traffic. Inspecting a record's raw JSON is a right-click action on any row.
 
 ## License
 
-MIT — see [LICENSE](./LICENSE).
+MIT — see [LICENSE](./LICENSE). Contributions welcome under DCO sign-off — see
+[CONTRIBUTING.md](./CONTRIBUTING.md) (no CLA).
 
 Developed by the Loobric project team. Thanks to the FreeCAD community for the
 CAM workbench and to the ISO 13399 standard for tool-data modeling.


### PR DESCRIPTION
Adds the DCO half of the M0 contribution policy (loobric/smooth-core#1) for this MIT reference client.

- `.github/workflows/dco.yml` — self-contained DCO check; fails PRs with any unsigned commit.
- `CONTRIBUTING.md` — DCO sign-off only, explicitly no CLA.
- README links to the contributing guide.

This PR's own commit is signed off, so it passes the new check.

Refs loobric/smooth-core#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)